### PR TITLE
add support for validation subdivision / country

### DIFF
--- a/pystreet/automaton.py
+++ b/pystreet/automaton.py
@@ -44,3 +44,24 @@ def boundary_check(string, start_idx, end_idx):
     )
 
     return (start_clause and end_clause)
+
+
+def match_automaton(string, automaton, boundary_check=None):
+    """
+    See if can match string to string matching automaton.
+    This is aided by a boundary check callable which helps ascertain
+    whether the matched substring occurs within some boundaries (e.g. token boundaries).
+
+    """
+    for end_position, (length, *tail) in automaton.iter(string):
+        end_idx = end_position + 1
+        start_idx = end_idx - length
+
+        if boundary_check and not boundary_check(string, start_idx, end_idx):
+            # Make sure string match aligns with word boundaries
+            continue
+
+        # If we reached here, can short circuit
+        return True
+
+    return False

--- a/pystreet/data.py
+++ b/pystreet/data.py
@@ -5,9 +5,26 @@ Data helpers.
 import pycountry
 
 
+def non_qualified_code(code):
+    """
+    Some codes, e.g. ISO 3166-2 subdivision codes, are compound and are formatted as
+    "{country_code}-{subdivision_code}". For validation cases we often care about
+    extracting the non-qualified subdivision code in such cases.
+
+    """
+    return code.split("-", 2)[1]
+
+
 def iter_country_names():
     for country in pycountry.countries:
         if hasattr(country, "official_name"):
             yield country.official_name
         yield country.name
         yield country.alpha_3
+
+
+def iter_subdivision_names():
+    for subdivision in pycountry.subdivisions:
+        yield subdivision.name
+        yield subdivision.code
+        yield non_qualified_code(subdivision.code)

--- a/pystreet/tests/test_validator.py
+++ b/pystreet/tests/test_validator.py
@@ -5,20 +5,26 @@ from pystreet.validator import nonstrict_address_validator
 
 
 @parameterized([
-    ("Schlesische Str. 25/26, 10997 Berlin, Germany",),
-    ("Goethestrasse 81, Düsseldorf, Germany 40237"),
-    ("Al. Prymasa Tysiaclecia 43B / 24, Warszawa, Mazowieckie, Poland 01-242"),
-    ("Szachowa 3, Warszawa, mazowieckie, Poland 04-894"),
-    ("Guðríðarstígur 2-4, 111, Reykjavík, Iceland"),
-    ("Signor Paolo Gaspari Enterprise Hotel CORSO SEMPIONE 91 20149 MILANO MI ITALY"),
-    ("8 Homewood Pl #100, Menlo Park, CA 94025 United States",),
-    ("560 Mission St #1200, San Francisco, CA 94105 USA",),
+    # format is: (string, require_country, require_subdivision)
+    ("Schlesische Str. 25/26, 10997 Berlin, Germany", True, True),
+    ("Goethestrasse 81, Düsseldorf, Germany 40237", True, False),
+    ("Al. Prymasa Tysiaclecia 43B / 24, Warszawa, Mazowieckie, Poland 01-242", True, True),
+    ("Szachowa 3, Warszawa, mazowieckie, Poland 04-894", True, True),
+    ("Guðríðarstígur 2-4, 111, Reykjavík, Iceland", True, True),
+    ("Signor Paolo Gaspari Enterprise Hotel CORSO SEMPIONE 91 20149 MILANO MI ITALY", True, True),
+    ("8 Homewood Pl #100, Menlo Park, CA 94025 United States", True, True),
+    ("560 Mission St #1200, San Francisco, CA 94105 USA", True, True),
 ])
-def test_nonstrict_validator_on_valid_cases(string):
-    validator = nonstrict_address_validator()
+def test_nonstrict_validator_on_valid_cases(string, require_country, require_subdivision):
+    validator = nonstrict_address_validator(
+        require_country=require_country,
+        require_subdivision=require_subdivision,
+    )
 
     assert_that(
-        validator(string),
+        validator(
+            string=string,
+        ),
         is_(True),
     )
 

--- a/pystreet/validator.py
+++ b/pystreet/validator.py
@@ -5,12 +5,7 @@ Street address validators.
 import re
 from abc import ABCMeta, abstractmethod
 
-from pystreet.automaton import (
-        boundary_check,
-        build_automaton,
-        match_automaton,
-        normalize,
-)
+from pystreet.automaton import boundary_check, build_automaton, match_automaton, normalize
 from pystreet.data import iter_country_names, iter_subdivision_names
 
 


### PR DESCRIPTION
This PR extends the basic non-strict street address validator to support validating against [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) country subdivisions database (via `pycountry` library) which we may be desirable in some use cases. 

- Add support for `require_subdivision` flag (+introduce `require_country` flag to make togglable as well)
- Update unit-tests to support for this